### PR TITLE
[CLEANUP] Default caching framework cache names changed - #88366

### DIFF
--- a/Classes/Controller/Typo3CacheExamples/CarController.php
+++ b/Classes/Controller/Typo3CacheExamples/CarController.php
@@ -63,8 +63,8 @@ class CarController
      *  - annotation 'restler_typo3cache_tags' (comma-separated list of cache-tags) is set
      *
      * The cache is stored in this TYPO3-tables:
-     *  - cf_cache_restler
-     *  - cf_cache_restler_tags
+     *  - cache_restler
+     *  - cache_restler_tags
      *
      * @url GET cars/{id}
      *


### PR DESCRIPTION
See: https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/10.0/Deprecation-88366-DefaultCachingFrameworkCacheNamesChanged.html