### PR TITLE
Increase php version dependency

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -23,7 +23,7 @@ $EM_CONF[$_EXTKEY] = [
     'constraints' => [
         'depends' => [
             'typo3' => '10.4.0-10.4.99',
-            'php' => '7.2.0-7.4.0',
+            'php' => '7.2.0-7.4.99',
             'restler' => '10.0.0-0.0.0'
         ],
         'conflicts' => [],


### PR DESCRIPTION
The upper range was fixed to 7.4.0, which is probably not used anywhere.I would suggest to increase to 7.4.99 in order to suppress warnings when installing in TYPO3.